### PR TITLE
docs: update documentation to reference version 0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This repository contains the following crates:
 ### Import the crate
 
 ```toml
-agenterra-rmcp = { version = "0.1", features = ["server"] }
+agenterra-rmcp = { version = "0.1.5", features = ["server"] }
 ## or from git
 agenterra-rmcp = { git = "https://github.com/agenterra/agenterra-rmcp", branch = "main" }
 ```

--- a/docs/OAUTH_SUPPORT.md
+++ b/docs/OAUTH_SUPPORT.md
@@ -1,5 +1,7 @@
 # Model Context Protocol OAuth Authorization
 
+> **Note**: This documentation is for the Agenterra fork of the official [Model Context Protocol Rust SDK](https://github.com/modelcontextprotocol/rust-sdk).
+
 This document describes the OAuth 2.1 authorization implementation for Model Context Protocol (MCP), following the [MCP 2025-03-26 Authorization Specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/).
 
 ## Features
@@ -19,7 +21,7 @@ Enable the auth feature in Cargo.toml:
 
 ```toml
 [dependencies]
-rmcp = { version = "0.1", features = ["auth", "transport-sse-client"] }
+agenterra-rmcp = { version = "0.1.5", features = ["auth", "transport-sse-client"] }
 ```
 
 ### 2. Use OAuthState

--- a/docs/readme/README.zh-cn.md
+++ b/docs/readme/README.zh-cn.md
@@ -1,7 +1,9 @@
-# RMCP
-[![Crates.io Version](https://img.shields.io/crates/v/rmcp)](https://crates.io/crates/rmcp)
-![Release status](https://github.commodelcontextprotocol/rust-sdk/actions/workflows/release.yml/badge.svg)
-[![docs.rs](https://img.shields.io/docsrs/rmcp)](https://docs.rs/rmcp/latest/rmcp)
+# Agenterra RMCP
+
+> **注意**: 这是官方 [Model Context Protocol Rust SDK](https://github.com/modelcontextprotocol/rust-sdk) 的分支版本。为了发布到 crates.io，包名已重命名为 `agenterra-rmcp` 和 `agenterra-rmcp-macros`。
+
+[![Crates.io Version](https://img.shields.io/crates/v/agenterra-rmcp)](https://crates.io/crates/agenterra-rmcp)
+[![docs.rs](https://img.shields.io/docsrs/agenterra-rmcp)](https://docs.rs/agenterra-rmcp/latest/agenterra_rmcp)
 
 一个基于tokio异步运行时的官方Model Context Protocol SDK实现。
 
@@ -9,15 +11,15 @@
 
 ### 导入
 ```toml
-rmcp = { version = "0.1", features = ["server"] }
+agenterra-rmcp = { version = "0.1.5", features = ["server"] }
 ## 或者开发者频道
-rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", branch = "main" }
+agenterra-rmcp = { git = "https://github.com/clafollett/agenterra-rmcp", branch = "main" }
 ```
 
 ### 快速上手
 一行代码启动客户端：
 ```rust
-use rmcp::{ServiceExt, transport::{TokioChildProcess, ConfigureCommandExt}};
+use agenterra_rmcp::{ServiceExt, transport::{TokioChildProcess, ConfigureCommandExt}};
 use tokio::process::Command;
 
 let client = ().serve(TokioChildProcess::new(Command::new("npx").configure(|cmd| {
@@ -82,7 +84,7 @@ let quit_reason = server.cancel().await?;
 
 请看这个[文件](examples/servers/src/common/calculator.rs)。
 ```rust, ignore
-use rmcp::{ServerHandler, model::ServerInfo, schemars, tool};
+use agenterra_rmcp::{ServerHandler, model::ServerInfo, schemars, tool};
 
 use super::counter::Counter;
 


### PR DESCRIPTION
## Summary
Updates documentation files to reference the newly published version 0.1.5 and correct crate name.

## Changes
- Update version from 0.1 to 0.1.5 in Chinese README
- Update version from 0.1 to 0.1.5 in OAuth documentation  
- Replace `rmcp` with `agenterra-rmcp` in both files
- Add proper attribution notes (English for OAuth docs, Chinese for Chinese README)

## Related Issue
Closes #3

## Test Plan
Documentation changes only - no code changes to test.

🤖 Generated with [Claude Code](https://claude.ai/code)